### PR TITLE
Added right-click Elytra swapping support for Forge and Fabric 1.20.1.

### DIFF
--- a/1.20.1/Common/src/main/java/fuzs/armorquickswap/handler/ArmorStandGearHandler.java
+++ b/1.20.1/Common/src/main/java/fuzs/armorquickswap/handler/ArmorStandGearHandler.java
@@ -1,58 +1,109 @@
-package fuzs.armorquickswap.handler;
+package fuzs.armorquickswap.client.handler;
 
-import fuzs.armorquickswap.mixin.accessor.ArmorStandAccessor;
-import fuzs.puzzleslib.api.event.v1.core.EventResultHolder;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EquipmentSlot;
-import net.minecraft.world.entity.decoration.ArmorStand;
+import com.google.common.collect.Maps;
+import com.mojang.blaze3d.platform.InputConstants;
+import fuzs.puzzleslib.api.client.screen.v2.ScreenHelper;
+import fuzs.puzzleslib.api.event.v1.core.EventResult;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickType;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Equipable;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.Vec3;
 
-public class ArmorStandGearHandler {
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
 
-    public static EventResultHolder<InteractionResult> onUseEntityAt(Player player, Level level, InteractionHand interactionHand, Entity entity, Vec3 hitVector) {
+public class InventoryArmorClickHandler {
+    private static final Map<Class<? extends Slot>, UnaryOperator<Slot>> SLOT_CLAZZ_METHOD_HANDLES = Maps.newIdentityHashMap();
 
-        if (entity instanceof ArmorStand armorStand && player.isShiftKeyDown() && !armorStand.isMarker() && !player.isSpectator()) {
+    public static EventResult onBeforeMouseClick(AbstractContainerScreen<?> screen, double mouseX, double mouseY, int button) {
 
-            if (!level.isClientSide) {
+        if (button != InputConstants.MOUSE_BUTTON_RIGHT) return EventResult.PASS;
 
-                for (EquipmentSlot equipmentSlot : EquipmentSlot.values()) {
+        Slot hoveredSlot = ScreenHelper.INSTANCE.findSlot(screen, mouseX, mouseY);
 
-                    if (equipmentSlot.isArmor()) {
+        if (hoveredSlot != null) {
+            ItemStack itemStack = hoveredSlot.getItem();
+            Equipable equipable = Equipable.get(itemStack);
 
-                        swapItem(armorStand, player, equipmentSlot);
+            if (equipable != null && !itemStack.isStackable()) {
+
+                Minecraft minecraft = ScreenHelper.INSTANCE.getMinecraft(screen);
+                Inventory inventory = minecraft.player.getInventory();
+
+                hoveredSlot = findNestedSlot(hoveredSlot);
+                if (hoveredSlot.container != inventory) return EventResult.PASS;
+
+                Slot armorSlot = LocalArmorStandGearHandler.findInventorySlot(screen.getMenu(), equipable.getEquipmentSlot().getIndex(inventory.items.size()));
+                if (armorSlot == null) return EventResult.PASS;
+
+                if (!ItemStack.isSameItemSameTags(hoveredSlot.getItem(), armorSlot.getItem())) {
+
+                    if (minecraft.gameMode.hasInfiniteItems()) {
+
+                        performCreativeItemSwap(minecraft.player, hoveredSlot, armorSlot);
+                    } else {
+
+                        minecraft.gameMode.handleInventoryMouseClick(screen.getMenu().containerId, armorSlot.index, hoveredSlot.getContainerSlot(), ClickType.SWAP, minecraft.player);
+                    }
+                }
+
+                return EventResult.INTERRUPT;
+            }
+        }
+
+        return EventResult.PASS;
+    }
+
+    private static void performCreativeItemSwap(Player player, Slot hoveredSlot, Slot armorSlot) {
+        ItemStack hoveredItem = hoveredSlot.getItem();
+        ItemStack armorItem = armorSlot.getItem();
+        player.getInventory().setItem(hoveredSlot.getContainerSlot(), armorItem.copy());
+        player.getInventory().setItem(armorSlot.getContainerSlot(), hoveredItem.copy());
+        player.inventoryMenu.broadcastChanges();
+    }
+
+    public static Slot findNestedSlot(Slot slot) {
+        return findNestedSlot(slot, 5);
+    }
+
+    private static Slot findNestedSlot(Slot slot, int searchDepth) {
+        Objects.requireNonNull(slot, "slot is null");
+        slot = SLOT_CLAZZ_METHOD_HANDLES.computeIfAbsent(slot.getClass(), clazz -> findNestedSlot(clazz, searchDepth)).apply(slot);
+        Objects.requireNonNull(slot, "slot is null");
+        return slot;
+    }
+
+    private static UnaryOperator<Slot> findNestedSlot(Class<? extends Slot> clazz, int searchDepth) {
+        // the creative mode screen wraps slots, but in a terrible way where not all properties of the original are forwarded, mainly public fields,
+        // so we use this general approach in case another mod has a similar idea and just search for a wrapped slot inside every slot instance
+        // the resulting method handle is cached, so this isn't really a burden (not that the code runs often anyway)
+        if (searchDepth >= 0 && clazz != Slot.class) {
+            for (Field field : clazz.getDeclaredFields()) {
+                if (Slot.class.isAssignableFrom(field.getType()) && !clazz.isAssignableFrom(field.getType())) {
+                    field.setAccessible(true);
+                    try {
+                        MethodHandle methodHandle = MethodHandles.lookup().unreflectGetter(field);
+                        return innerSlot -> {
+                            try {
+                                return findNestedSlot((Slot) methodHandle.invoke(innerSlot), searchDepth - 1);
+                            } catch (Throwable e) {
+                                throw new RuntimeException(e);
+                            }
+                        };
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
                     }
                 }
             }
-
-            return EventResultHolder.interrupt(InteractionResult.sidedSuccess(level.isClientSide));
         }
-
-        return EventResultHolder.pass();
-    }
-
-    private static boolean swapItem(ArmorStand armorStand, Player player, EquipmentSlot slot) {
-        ItemStack stack = player.getItemBySlot(slot);
-        ItemStack itemInSlot = armorStand.getItemBySlot(slot);
-        // we respect disabled slots on the server, this is not possible to do with the client-side implementation
-        int disabledSlots = ((ArmorStandAccessor) armorStand).armorquickswap$getDisabledSlots();
-        if ((disabledSlots & 1 << slot.getFilterFlag()) != 0) {
-            return false;
-        } else if (!stack.isEmpty() && stack.getCount() > 1) {
-            if (!itemInSlot.isEmpty()) {
-                return false;
-            } else {
-                armorStand.setItemSlot(slot, stack.split(1));
-                return true;
-            }
-        } else {
-            armorStand.setItemSlot(slot, stack);
-            player.setItemSlot(slot, itemInSlot);
-            return true;
-        }
+        return UnaryOperator.identity();
     }
 }


### PR DESCRIPTION
File modified: 1.20.1/Common/src/main/java/fuzs/armorquickswap/client/handler/InventoryArmorClickHandler.java

Updated Imports: Replaced ArmorItem with Equipable.

Updated the Click Handler Logic: Changed the instance check from ArmorItem to use the Equipable interface and ensuring the item is not stackable, matching the logic introduced in the 1.21.1 version.


I edited the wrong file XD